### PR TITLE
A handful of nits and maybe improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ supply it to the drawing procedure.
 ## Example Usage
 
 ```rust
-use std::fmt::Display;
+use std::fmt;
+
 use syntree::Builder;
 use syntree_layout::{Layouter, Result, Visualize};
 
@@ -59,9 +60,10 @@ struct MyNodeData(i32);
 // node representation.
 // You should use `Layouter::embed_with_visualize`
 impl Visualize for MyNodeData {
-    fn visualize(&self) -> std::string::String {
-        format!("Id({})", self.0)
+    fn visualize(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Id({})", self.0)
     }
+
     fn emphasize(&self) -> bool {
         // This simply emphasizes only the leaf nodes.
         // It only works for this example.
@@ -70,8 +72,8 @@ impl Visualize for MyNodeData {
 }
 
 // Display implementation is necessary if you want to use `Layouter::embed`
-impl Display for MyNodeData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+impl fmt::Display for MyNodeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/README.md
+++ b/README.md
@@ -94,17 +94,17 @@ fn main() -> Result<()> {
 
     let tree = tree.build().unwrap();
     Layouter::new(&tree)
-        .with_file_path(std::path::Path::new("examples/example1_vis.svg"))
+        .with_file_path("examples/example1_vis.svg")
         .embed_with_visualize()?
         .write()?;
 
     Layouter::new(&tree)
-        .with_file_path(std::path::Path::new("examples/example1_deb.svg"))
+        .with_file_path("examples/example1_deb.svg")
         .embed_with_debug()?
         .write()?;
 
     Layouter::new(&tree)
-        .with_file_path(std::path::Path::new("examples/example1_dis.svg"))
+        .with_file_path("examples/example1_dis.svg")
         .embed()?
         .write()
 }

--- a/examples/example1.rs
+++ b/examples/example1.rs
@@ -1,4 +1,5 @@
-use std::fmt::Display;
+use std::fmt;
+
 use syntree::Builder;
 use syntree_layout::{Layouter, Result, Visualize};
 
@@ -8,9 +9,10 @@ struct MyNodeData(i32);
 // You need to implement syntree_layout::Visualize for your nodes data type if you want your own
 // node representation.
 impl Visualize for MyNodeData {
-    fn visualize(&self) -> std::string::String {
-        format!("Id({})", self.0)
+    fn visualize(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Id({})", self.0)
     }
+
     fn emphasize(&self) -> bool {
         // This simply emphasizes only the leaf nodes.
         // It only works for this example.
@@ -18,8 +20,8 @@ impl Visualize for MyNodeData {
     }
 }
 
-impl Display for MyNodeData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+impl fmt::Display for MyNodeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/examples/example1.rs
+++ b/examples/example1.rs
@@ -42,17 +42,17 @@ fn main() -> Result<()> {
 
     let tree = tree.build().unwrap();
     Layouter::new(&tree)
-        .with_file_path(std::path::Path::new("examples/example1_vis.svg"))
+        .with_file_path("examples/example1_vis.svg")
         .embed_with_visualize()?
         .write()?;
 
     Layouter::new(&tree)
-        .with_file_path(std::path::Path::new("examples/example1_deb.svg"))
+        .with_file_path("examples/example1_deb.svg")
         .embed_with_debug()?
         .write()?;
 
     Layouter::new(&tree)
-        .with_file_path(std::path::Path::new("examples/example1_dis.svg"))
+        .with_file_path("examples/example1_dis.svg")
         .embed()?
         .write()
 }

--- a/examples/example2.rs
+++ b/examples/example2.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use syntree_layout::{Layouter, Visualize};
 
 #[derive(Debug)]
@@ -37,39 +38,41 @@ enum Ast {
 }
 
 impl Visualize for Ast {
-    fn visualize(&self) -> String {
-        match self {
-            Ast::Calc => "calc".to_string(),
-            Ast::CalcLst1 => "calc_lst1".to_string(),
-            Ast::CalcLst1Itm1 => "calc_lst1_itm1".to_string(),
-            Ast::Instruction => "instruction".to_string(),
-            Ast::Assignment => "assignment".to_string(),
-            Ast::AssignItem => "assign_item".to_string(),
-            Ast::Id => "id".to_string(),
-            Ast::AssignOp => "assign_op".to_string(),
-            Ast::LocigalOr => "locigal_or".to_string(),
-            Ast::LocigalAnd => "locigal_and".to_string(),
-            Ast::BitwiseOr => "bitwise_or".to_string(),
-            Ast::BitwiseAnd => "bitwise_and".to_string(),
-            Ast::Equality => "equality".to_string(),
-            Ast::Relational => "relational".to_string(),
-            Ast::BitwiseShift => "bitwise_shift".to_string(),
-            Ast::Sum => "sum".to_string(),
-            Ast::Mult => "mult".to_string(),
-            Ast::Power => "power".to_string(),
-            Ast::Factor => "factor".to_string(),
-            Ast::Number => "number".to_string(),
-            Ast::MultLst1 => "mult_lst1".to_string(),
-            Ast::MultLst1Itm1 => "mult_lst1_itm1".to_string(),
-            Ast::MultItem => "mult_item".to_string(),
-            Ast::MultOp => "mult_op".to_string(),
-            Ast::SumLst1 => "sum_lst1".to_string(),
-            Ast::SumLst1Itm1 => "sum_lst1_itm1".to_string(),
-            Ast::SumItem => "sum_item".to_string(),
-            Ast::AddOp => "add_op".to_string(),
-            Ast::Plus => "plus".to_string(),
-            Ast::Tok(s) => s.to_string(),
-        }
+    fn visualize(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Ast::Calc => "calc",
+            Ast::CalcLst1 => "calc_lst1",
+            Ast::CalcLst1Itm1 => "calc_lst1_itm1",
+            Ast::Instruction => "instruction",
+            Ast::Assignment => "assignment",
+            Ast::AssignItem => "assign_item",
+            Ast::Id => "id",
+            Ast::AssignOp => "assign_op",
+            Ast::LocigalOr => "locigal_or",
+            Ast::LocigalAnd => "locigal_and",
+            Ast::BitwiseOr => "bitwise_or",
+            Ast::BitwiseAnd => "bitwise_and",
+            Ast::Equality => "equality",
+            Ast::Relational => "relational",
+            Ast::BitwiseShift => "bitwise_shift",
+            Ast::Sum => "sum",
+            Ast::Mult => "mult",
+            Ast::Power => "power",
+            Ast::Factor => "factor",
+            Ast::Number => "number",
+            Ast::MultLst1 => "mult_lst1",
+            Ast::MultLst1Itm1 => "mult_lst1_itm1",
+            Ast::MultItem => "mult_item",
+            Ast::MultOp => "mult_op",
+            Ast::SumLst1 => "sum_lst1",
+            Ast::SumLst1Itm1 => "sum_lst1_itm1",
+            Ast::SumItem => "sum_item",
+            Ast::AddOp => "add_op",
+            Ast::Plus => "plus",
+            Ast::Tok(s) => s,
+        };
+
+        write!(f, "{s}")
     }
 
     fn emphasize(&self) -> bool {

--- a/examples/example2.rs
+++ b/examples/example2.rs
@@ -148,7 +148,7 @@ fn main() -> std::result::Result<(), anyhow::Error> {
     };
 
     Layouter::new(&tree)
-        .with_file_path(std::path::Path::new("examples/example2.svg"))
+        .with_file_path("examples/example2.svg")
         .embed_with_visualize()
         .map_err(|e| anyhow::anyhow!(e))?
         .write()

--- a/src/drawer.rs
+++ b/src/drawer.rs
@@ -8,3 +8,16 @@ use crate::{EmbeddedNode, Result};
 pub trait Drawer {
     fn draw(&self, file_name: &std::path::Path, embedding: &[EmbeddedNode]) -> Result<()>;
 }
+
+struct DummyDrawer;
+
+impl Drawer for DummyDrawer {
+    #[inline]
+    fn draw(&self, _: &std::path::Path, _: &[EmbeddedNode]) -> Result<()> {
+        Ok(())
+    }
+}
+
+// Test to assert that drawer is object safe, even though this is *for now*
+// ensured in the bound used in `Layouter::new`.
+const _: &dyn Drawer = &DummyDrawer;

--- a/src/internal/embedder.rs
+++ b/src/internal/embedder.rs
@@ -2,10 +2,7 @@
 
 use syntree::{index::Index, node::Event, pointer::Width, Node, Tree};
 
-use crate::{
-    layouter::{EmphasizeFunction, StringifyFunction},
-    Embedding, LayouterError, Result,
-};
+use crate::{Embedding, LayouterError, Result};
 
 use super::node::{EmbeddingHelperData, InternalNode};
 
@@ -39,8 +36,8 @@ where
     ///
     pub(crate) fn embed(
         tree: &Tree<T, I, W>,
-        stringify: StringifyFunction<T>,
-        emphasize: EmphasizeFunction<T>,
+        stringify: impl Fn(&T) -> String,
+        emphasize: impl Fn(&T) -> bool,
     ) -> Result<Embedding> {
         // Insert all tree items with their indices
         // After this step each item has following properties set:
@@ -67,8 +64,8 @@ where
         depth: usize,
         node: Node<T, I, W>,
         items: &EmbeddingHelperData<W>,
-        stringify: &StringifyFunction<T>,
-        emphasize: &EmphasizeFunction<T>,
+        stringify: &impl Fn(&T) -> String,
+        emphasize: &impl Fn(&T) -> bool,
     ) -> InternalNode<W> {
         let text = stringify(node.value());
         let y_order = depth;
@@ -98,8 +95,8 @@ where
 
     fn create_initial_embedding_data(
         tree: &Tree<T, I, W>,
-        stringify: &StringifyFunction<T>,
-        emphasize: &EmphasizeFunction<T>,
+        stringify: &impl Fn(&T) -> String,
+        emphasize: &impl Fn(&T) -> bool,
     ) -> Result<EmbeddingHelperData<W>> {
         let mut items = EmbeddingHelperData::with_capacity(tree.len());
         if tree.children().count() > 1 {

--- a/src/layouter.rs
+++ b/src/layouter.rs
@@ -9,9 +9,6 @@ use crate::{
     internal::embedder::Embedder, Drawer, Embedding, LayouterError, Result, SvgDrawer, Visualize,
 };
 
-pub type StringifyFunction<T> = Box<dyn Fn(&T) -> String>;
-pub type EmphasizeFunction<T> = Box<dyn Fn(&T) -> bool>;
-
 ///
 /// The Layouter type provides a simple builder mechanism with a fluent API.
 ///
@@ -207,8 +204,8 @@ where
     pub fn embed_with_visualize(self) -> Result<Self> {
         let embedding = Embedder::embed(
             self.tree,
-            Box::new(|value: &T| value.visualize()),
-            Box::new(|value: &T| value.emphasize()),
+            |value: &T| value.visualize(),
+            |value: &T| value.emphasize(),
         )?;
         Ok(Self {
             tree: self.tree,
@@ -238,8 +235,8 @@ where
     pub fn embed_with_debug(self) -> Result<Self> {
         let embedding = Embedder::embed(
             self.tree,
-            Box::new(|value: &T| format!("{value:?}")),
-            Box::new(|_value: &T| false),
+            |value: &T| format!("{value:?}"),
+            |_value: &T| false,
         )?;
         Ok(Self {
             tree: self.tree,
@@ -269,8 +266,8 @@ where
     pub fn embed(self) -> Result<Self> {
         let embedding = Embedder::embed(
             self.tree,
-            Box::new(|value: &T| format!("{value}")),
-            Box::new(|_value: &T| false),
+            |value: &T| format!("{value}"),
+            |_value: &T| false,
         )?;
         Ok(Self {
             tree: self.tree,
@@ -299,10 +296,10 @@ where
     ///
     pub fn embed_with(
         &self,
-        stringify: StringifyFunction<T>,
-        emphasize: EmphasizeFunction<T>,
+        stringify: impl Fn(&T) -> String,
+        emphasize: impl Fn(&T) -> bool,
     ) -> Result<Self> {
-        let embedding = Embedder::embed(self.tree, stringify, emphasize)?;
+        let embedding = Embedder::embed(self.tree, &stringify, &emphasize)?;
         Ok(Self {
             tree: self.tree,
             file_name: self.file_name,

--- a/src/layouter.rs
+++ b/src/layouter.rs
@@ -14,18 +14,18 @@ pub type EmphasizeFunction<T> = Box<dyn Fn(&T) -> bool>;
 ///
 /// The Layouter type provides a simple builder mechanism with a fluent API.
 ///
-pub struct Layouter<'t, 'd, 'p, T, I, W>
+pub struct Layouter<'a, T, I, W>
 where
     I: Index,
     W: Width,
 {
-    tree: &'t Tree<T, I, W>,
-    drawer: Option<&'d dyn Drawer>,
-    file_name: Option<&'p std::path::Path>,
+    tree: &'a Tree<T, I, W>,
+    drawer: Option<&'a dyn Drawer>,
+    file_name: Option<&'a std::path::Path>,
     embedding: Embedding,
 }
 
-impl<'t, 'd, 'p, T, I, W> Layouter<'t, 'd, 'p, T, I, W>
+impl<'a, T, I, W> Layouter<'a, T, I, W>
 where
     I: Index,
     W: Width,
@@ -49,7 +49,7 @@ where
     /// let layouter = Layouter::new(&tree);
     /// ```
     ///
-    pub fn new(tree: &'t Tree<T, I, W>) -> Self {
+    pub fn new(tree: &'a Tree<T, I, W>) -> Self {
         Self {
             tree,
             drawer: None,
@@ -79,7 +79,7 @@ where
     ///     .with_file_path(Path::new("target/tmp/test.svg"));
     /// ```
     ///
-    pub fn with_file_path(self, path: &'p std::path::Path) -> Self {
+    pub fn with_file_path(self, path: &'a std::path::Path) -> Self {
         Self {
             tree: self.tree,
             file_name: Some(path),
@@ -89,7 +89,7 @@ where
     }
 
     ///
-    /// Sets a different drawer when you don't want to use the default svg-drawer.
+    /// Sets a different drawer when you don'a want to use the default svg-drawer.
     /// If this method is not called the crate's own svg-drawer is used.
     ///
     /// ```
@@ -119,7 +119,7 @@ where
     ///     .with_file_path(Path::new("target/tmp/test.svg"));
     /// ```
     ///
-    pub fn with_drawer(self, drawer: &'d dyn Drawer) -> Self {
+    pub fn with_drawer(self, drawer: &'a dyn Drawer) -> Self {
         Self {
             tree: self.tree,
             file_name: self.file_name,
@@ -174,7 +174,7 @@ where
     }
 }
 
-impl<'t, 'd, 'p, T, I, W> Layouter<'t, 'd, 'p, T, I, W>
+impl<'a, T, I, W> Layouter<'a, T, I, W>
 where
     T: Visualize,
     I: Index,
@@ -205,7 +205,7 @@ where
     }
 }
 
-impl<'t, 'd, 'p, T, I, W> Layouter<'t, 'd, 'p, T, I, W>
+impl<'a, T, I, W> Layouter<'a, T, I, W>
 where
     T: Debug,
     I: Index,
@@ -235,7 +235,7 @@ where
     }
 }
 
-impl<'t, 'd, 'p, T, I, W> Layouter<'t, 'd, 'p, T, I, W>
+impl<'a, T, I, W> Layouter<'a, T, I, W>
 where
     T: Display,
     I: Index,
@@ -265,7 +265,7 @@ where
     }
 }
 
-impl<'t, 'd, 'p, T, I, W> Layouter<'t, 'd, 'p, T, I, W>
+impl<'a, T, I, W> Layouter<'a, T, I, W>
 where
     I: Index,
     W: Width,

--- a/src/layouter.rs
+++ b/src/layouter.rs
@@ -1,6 +1,7 @@
 //! The module with the **Public API**.
 
 use std::fmt::{Debug, Display};
+use std::path::Path;
 
 use syntree::{index::Index, pointer::Width, Tree};
 
@@ -21,7 +22,7 @@ where
 {
     tree: &'a Tree<T, I, W>,
     drawer: Option<&'a dyn Drawer>,
-    file_name: Option<&'a std::path::Path>,
+    file_name: Option<&'a Path>,
     embedding: Embedding,
 }
 
@@ -64,7 +65,6 @@ where
     /// ```
     /// use syntree_layout::{Layouter, Visualize};
     /// use syntree::{Tree, Builder};
-    /// use std::path::Path;
     ///
     /// struct MyNodeData(i32);
     ///
@@ -76,13 +76,16 @@ where
     ///
     /// let tree: Tree<MyNodeData, _, _> = Builder::new().build().unwrap();
     /// let layouter = Layouter::new(&tree)
-    ///     .with_file_path(Path::new("target/tmp/test.svg"));
+    ///     .with_file_path("target/tmp/test.svg");
     /// ```
     ///
-    pub fn with_file_path(self, path: &'a std::path::Path) -> Self {
+    pub fn with_file_path<P>(self, path: &'a P) -> Self
+    where
+        P: ?Sized + AsRef<Path>,
+    {
         Self {
             tree: self.tree,
-            file_name: Some(path),
+            file_name: Some(path.as_ref()),
             drawer: self.drawer,
             embedding: self.embedding,
         }
@@ -116,7 +119,7 @@ where
     /// let drawer = NilDrawer;
     /// let layouter = Layouter::new(&tree)
     ///     .with_drawer(&drawer)
-    ///     .with_file_path(Path::new("target/tmp/test.svg"));
+    ///     .with_file_path("target/tmp/test.svg");
     /// ```
     ///
     pub fn with_drawer(self, drawer: &'a dyn Drawer) -> Self {
@@ -136,7 +139,6 @@ where
     /// ```
     /// use syntree_layout::{Layouter, Visualize, Result};
     /// use syntree::{Tree, Builder};
-    /// use std::path::Path;
     ///
     /// struct MyNodeData(i32);
     ///
@@ -148,7 +150,7 @@ where
     /// fn test() -> Result<()> {
     ///     let tree: Tree<MyNodeData, _, _> = Builder::new().build().unwrap();
     ///     Ok(Layouter::new(&tree)
-    ///         .with_file_path(Path::new("target/tmp/test.svg"))
+    ///         .with_file_path("target/tmp/test.svg")
     ///         .embed_with_visualize()?
     ///         .write().expect("Failed writing layout"))
     /// }

--- a/src/svg_drawer.rs
+++ b/src/svg_drawer.rs
@@ -21,7 +21,7 @@ pub struct SvgDrawer;
 
 impl SvgDrawer {
     /// Method to create a fresh instance of the `SvgDrawer` type.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 

--- a/src/visualize.rs
+++ b/src/visualize.rs
@@ -1,11 +1,13 @@
 //! The visualize module provides the `Visualize` trait.
 
+use std::fmt;
+
 /// The `Visualize` trait abstracts the visual presentation of the node's data.
 /// It can be implemented by the Tree<T, ...>'s node type T when custom visualization is desired.
 /// Only mandatory to implement is the `visualize` method.
 pub trait Visualize {
     /// Returns the string representation of the nodes data.
-    fn visualize(&self) -> String;
+    fn visualize(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
     /// When this method returns true the drawer can emphasize the node's string representation
     /// in an implementation dependent way, i.e. it can print it bold.

--- a/tests/embedder_tests.rs
+++ b/tests/embedder_tests.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use syntree::{Builder, Tree};
 use syntree_layout::{Layouter, Visualize};
 
@@ -5,8 +7,8 @@ use syntree_layout::{Layouter, Visualize};
 struct MyNodeData(i32);
 
 impl Visualize for MyNodeData {
-    fn visualize(&self) -> std::string::String {
-        self.0.to_string()
+    fn visualize(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
A few nits I noticed when looking over the library, feel free to accept, reject or modify any part of it at your own discretion:

`Layouter` doesn't seem to need multiple lifetimes. AFAIU, this should only be necessary if any one of the lifetimes it posesses ever "leaves" it in terms of its API. Otherwise every lifetime currently specified should simply abide by the constraint that it must be as short as possible, which should always necessarily be the lifetime of the `Layouter` struct itself. This is to the best of my understanding, but at least I can't figure out how to break it.

`with_file_name` can accept `AsRef<Path>`, allowing it to pretty much accept anything that `Path::new` accepts. Including a string.

Drawer doesn't have to be a dyn trait, instead with_drawer can return a `Layouter` with a different type signature. It also doesn't need an `Option` since `SvgDrawer` doesn't have any state!

`stringify` and `emphasize` are internally boxed, even though they don't have to be. I removed the type aliases (which makes the bounds a bit wordier) but since it's an internal `impl Trait` I'm not super worried. You tell me what you think.

Finally `Visualize::visualize` can avoid requiring allocating by implementing a `Display`-like API ([like serde does here](https://docs.rs/serde/latest/serde/de/trait.Visitor.html#tymethod.expecting)). Even though it's not used right now, it's nice if it ever needs to be composed and if `InternalNode` is reworked might even be able to work with a single string buffer in the future ;).